### PR TITLE
delete crane robot matters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rsj_2017_application)
 
-## Add support for C++11, supported in ROS Kinetic and newer
-# add_definitions(-std=c++11)
+## Add support for C++14, for ROS Noetic
+set(CMAKE_CXX_STANDARD 14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/launch/start_app.launch
+++ b/launch/start_app.launch
@@ -1,12 +1,6 @@
 <launch>
-  <param name="robot_description"
-    command="$(find xacro)/xacro --inorder '$(find rsj_2017_application)/urdf/work_cell.urdf.xacro'"
-    />
 
-  <include file="$(find crane_plus_hardware)/launch/start_arm.launch"/>
-  <include file="$(find crane_plus_moveit_config)/launch/move_group.launch"/>
-
-  <node name="camera" pkg="usb_cam" type="usb_cam_node" output="screen">
+    <node name="camera" pkg="usb_cam" type="usb_cam_node" output="log">
     <param name="camera_name" value="elecom_ucam"/>
     <param name="camera_frame_id" value="camera_link"/>
     <param name="video_device" value="/dev/video0"/>
@@ -16,11 +10,11 @@
     <param name="io_method" value="mmap"/>
   </node>
 
-  <node name="pickandplace" pkg="rsj_2017_pick_and_placer" type="rsj_2017_pick_and_placer_node" output="screen">
+  <node name="pickandplace" pkg="rsj_2017_pick_and_placer" type="rsj_2017_pick_and_placer_node" output="log">
     <remap from="/block" to="/block_finder/pose"/>
   </node>
 
-  <node name="block_finder" pkg="rsj_2017_block_finder" type="block_finder" output="screen">
+  <node name="block_finder" pkg="rsj_2017_block_finder" type="block_finder" output="log">
     <remap from="/usb_cam_node/camera_info" to="/camera/camera_info"/>
     <remap from="/usb_cam_node/image_raw" to="/camera/image_raw"/>
   </node>

--- a/launch/start_app.launch
+++ b/launch/start_app.launch
@@ -16,7 +16,7 @@
     <param name="io_method" value="mmap"/>
   </node>
 
-  <node name="pickandplace" pkg="rsj_2017_pick_and_placer" type="pick_and_placer" output="screen">
+  <node name="pickandplace" pkg="rsj_2017_pick_and_placer" type="rsj_2017_pick_and_placer_node" output="screen">
     <remap from="/block" to="/block_finder/pose"/>
   </node>
 


### PR DESCRIPTION
1. deleted crane robot related nodes.
2. suppressed node outputs by setting output="log", instead of "screen".

The intent of the change 1 assumes that 'start_app.launch' is called from some launch file which calls own robot, in the form of <include ...>.
